### PR TITLE
Fiddle with html2canvas

### DIFF
--- a/components/PngDownloadButton.tsx
+++ b/components/PngDownloadButton.tsx
@@ -8,6 +8,7 @@ type Properties = {
     scrollYOffset?: number
     windowWidthOffset?: number
     windowHeightOffset?: number
+    widthOffset?: number
 }
 
 export default function PngDownloadButton(
@@ -18,6 +19,7 @@ export default function PngDownloadButton(
         scrollYOffset = 0,
         windowWidthOffset = 0,
         windowHeightOffset = 0,
+        widthOffset = 0,
     }: Properties
 ) {
     async function download() {
@@ -32,6 +34,11 @@ export default function PngDownloadButton(
                 scrollY: -window.scrollY + scrollYOffset,
                 windowWidth: document.documentElement.offsetWidth + windowWidthOffset,
                 windowHeight: document.documentElement.offsetHeight + windowHeightOffset,
+                width: Math.max(
+                    node.current.scrollWidth ?? 0,
+                    node.current.offsetWidth ?? 0,
+                    node.current.clientWidth ?? 0,
+                ) + widthOffset,
             },
         })
     }

--- a/components/PngDownloadButton.tsx
+++ b/components/PngDownloadButton.tsx
@@ -4,12 +4,20 @@ import {Button} from "semantic-ui-react";
 type Properties = {
     node: MutableRefObject<any>
     name: string
+    scrollXOffset?: number
+    scrollYOffset?: number
+    windowWidthOffset?: number
+    windowHeightOffset?: number
 }
 
 export default function PngDownloadButton(
     {
         node,
         name,
+        scrollXOffset = 0,
+        scrollYOffset = 0,
+        windowWidthOffset = 0,
+        windowHeightOffset = 0,
     }: Properties
 ) {
     async function download() {
@@ -20,11 +28,10 @@ export default function PngDownloadButton(
         await exportComponentAsPNG(node, {
             fileName: name + '.png',
             html2CanvasOptions: {
-                width: Math.max(
-                    node.current.scrollWidth ?? 0,
-                    node.current.offsetWidth ?? 0,
-                    node.current.clientWidth ?? 0,
-                ) + 12,
+                scrollX: -window.scrollX + scrollXOffset,
+                scrollY: -window.scrollY + scrollYOffset,
+                windowWidth: document.documentElement.offsetWidth + windowWidthOffset,
+                windowHeight: document.documentElement.offsetHeight + windowHeightOffset,
             },
         })
     }

--- a/components/SummaryPage.tsx
+++ b/components/SummaryPage.tsx
@@ -1,5 +1,5 @@
 import {Container, Header, Ref} from "semantic-ui-react";
-import SummaryOptions, { MobileSummaryOptions } from "@/components/summary/SummaryOptions";
+import SummaryOptions from "@/components/summary/SummaryOptions";
 import React, {useEffect, useState} from "react";
 import getVersionParts from "@/banners/version";
 import _ from "lodash";

--- a/components/SummaryPage.tsx
+++ b/components/SummaryPage.tsx
@@ -70,7 +70,10 @@ export default function SummaryPage(
             </Ref>
 
             <Container text={!expand} style={{marginTop: '1em'}} textAlign={"center"}>
-                <PngDownloadButton node={ref} name={'summary'}/>
+                <PngDownloadButton node={ref} name={'summary'}
+                                   widthOffset={20}
+                                   scrollXOffset={10}
+                />
             </Container>
         </>
     )

--- a/components/banners/BannerPage.tsx
+++ b/components/banners/BannerPage.tsx
@@ -80,7 +80,7 @@ export default class BannerPage extends React.Component<Properties, States> {
                                    expand={expand} setExpand={setExpand}
                     />
                 </Container>
-                <Container style={{overflowX: 'scroll', marginTop: '1em',  ...getBannerContainerStyle(expand ?? false)}}
+                <Container style={{overflowX: 'scroll', marginTop: '1em', ...getBannerContainerStyle(expand ?? false)}}
                            fluid={expand ?? false}>
                     <ScrollContainer className="scroll-container" hideScrollbars={false} ignoreElements={'input'}>
                         <Ref innerRef={this.componentRef}>
@@ -98,7 +98,10 @@ export default class BannerPage extends React.Component<Properties, States> {
                     </ScrollContainer>
                 </Container>
                 <Container style={{marginTop: '2em'}} textAlign={'center'}>
-                    <PngDownloadButton node={this.componentRef} name={'banner-history'}/>
+                    <PngDownloadButton node={this.componentRef} name={'banner-history'}
+                                       scrollXOffset={15}
+                                       windowWidthOffset={20}
+                    />
                 </Container>
             </>
         )

--- a/components/banners/BannerSearch.tsx
+++ b/components/banners/BannerSearch.tsx
@@ -15,7 +15,7 @@ export default function BannerSearch(
             <Input fluid
                    placeholder={'Filter name...'}
                    onChange={_.debounce(onChange, 250)}
-                   style={{minWidth: '16em'}} icon>
+                   style={{minWidth: '16em'}} icon data-html2canvas-ignore>
                 <input autoComplete={'off'} />
                 <Icon name='search'/>
             </Input>

--- a/components/summary/SummaryOptions.tsx
+++ b/components/summary/SummaryOptions.tsx
@@ -96,7 +96,7 @@ export function DesktopSummaryOptions(
 
                         <Form.Group widths='equal'>
                             <Form.Radio
-                                label='Historical Longest Wait'
+                                label='Longest Wait Leaderboard'
                                 value='longest'
                                 checked={metric === 'longest'}
                                 onChange={() => setMetric('longest')}
@@ -106,7 +106,7 @@ export function DesktopSummaryOptions(
 
                         <Form.Group widths='equal'>
                             <Form.Radio
-                                label='Historical Shortest Wait'
+                                label='Shortest Wait Leaderboard'
                                 value='shortest'
                                 checked={metric === 'shortest'}
                                 onChange={() => setMetric('shortest')}
@@ -246,7 +246,7 @@ export function MobileSummaryOptions(
                     </Form.Group>
                     <Form.Group widths='equal'>
                         <Form.Radio
-                            label='Historical Longest Wait'
+                            label='Longest Wait Leaderboard'
                             value='longest'
                             checked={metric === 'longest'}
                             onChange={() => setMetric('longest')}
@@ -255,7 +255,7 @@ export function MobileSummaryOptions(
                     </Form.Group>
                     <Form.Group widths='equal'>
                         <Form.Radio
-                            label='Historical Shortest Wait'
+                            label='Shortest Wait Leaderboard'
                             value='shortest'
                             checked={metric === 'shortest'}
                             onChange={() => setMetric('shortest')}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -43,6 +43,11 @@ body {
     border: 1px solid #ddd;
 }
 
+/* oddly the first row's first col has no border top... */
+.history tr:first-of-type td:first-of-type {
+    border-top: 1px #ddd solid !important;
+}
+
 .history td:not(:first-of-type) {
     text-align: center !important;
 }


### PR DESCRIPTION
- Removed search/filter characters in the history page when downloading as PNG. It was kind of odd having it in there in the past.
- Adjusted the downloaded PNG to have extra whitespace to the left/right (it makes it look better to me).
- Renamed the longest/shortest summary options from historical to leaderboard. Feel like that may be the more appropriate terminology here.

Tested on my macbook firefox browser + bluestacks chrome browser. Seems to look better than before.