### PR TITLE
pin version of pnpm for clareflare

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "2.3.0",
   "private": true,
   "engines": {
-    "node": ">=16",
-    "pnpm": ">=3",
+    "node": ">=17",
+    "pnpm": ">=8",
     "npm": "use pnpm instead",
     "yarn": "use pnpm instead"
   },
   "scripts": {
-    "build:cloudflare": "npm install -g pnpm && pnpm install -P && next build && next export",
+    "build:cloudflare": "npm install -g pnpm@8.15.7 && pnpm install -P && next build && next export",
     "dev": "next dev",
     "build": "next build",
     "export": "next export",


### PR DESCRIPTION
default is now 9, which requires a higher version of node